### PR TITLE
Fixes #1 by forcing package names to string types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     license="Apache License 2.0",
     description = "A TCP/UDP Telegraf/InfluxDB client for Twisted.",
     long_description = read('README.rst'),
-    packages = ['txtelegraf'],
+    packages = [str('txtelegraf')],
     install_requires = ['twisted'],
     keywords=["twisted", "telegraf", "influxdb"],
     classifiers=[


### PR DESCRIPTION
This appears to be caused by a bug in distutils or setuptools or both. Some of the detail is outlined here: https://bugs.python.org/issue13943